### PR TITLE
Add autoplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here's a list of all the attributes you can set and change on the web component.
 - `channel-id` [string], a radio4000 channel id (ex: `-JYZvhj3vlGCjKXZ2cXO`)
 - `track-id` [string], a radio4000 track id (ex: `-JYEosmvT82Ju0vcSHVP`)
 - `volume` [integer] from 0 to 100
-- `autoplay` [boolean]
+- `autoplay` [boolean], if it should start playing automatically
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Here's a list of all the attributes you can set and change on the web component.
 - `channel-id` [string], a radio4000 channel id (ex: `-JYZvhj3vlGCjKXZ2cXO`)
 - `track-id` [string], a radio4000 track id (ex: `-JYEosmvT82Ju0vcSHVP`)
 - `volume` [integer] from 0 to 100
+- `autoplay` [boolean]
 
 ### Examples
 
@@ -40,6 +41,12 @@ player.trackId = '-JYEosmvT82Ju0vcSHVP'
 
 // Change the volume.
 player.volume = 25
+```
+
+To enable autoplay:
+
+```html
+<radio4000-player channel-slug="200ok" autoplay="true"></radio4000-player>
 ```
 
 ## Skins

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 		<div class="Grid">
 			<!-- <radio4000-player track-id="-JYZvhj3vlGCjKXZ2cXO"></radio4000-player> -->
 			<radio4000-player channel-id="-JYEosmvT82Ju0vcSHVP"></radio4000-player>
+			<!--<radio4000-player autoplay="true" channel-id="-JYEosmvT82Ju0vcSHVP"></radio4000-player>-->
 			<!-- <radio4000-player channel-slug="oskar"></radio4000-player> -->
 			
 			<!-- <radio4000-player channel-slug="200ok" class="dark purple"></radio4000-player> -->

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -1,5 +1,6 @@
 <template>
 	<radio4000-player
+			:autoplay="autoplay"
 			:channel="channel"
 			:tracks="tracks"
 			:track="track"
@@ -22,6 +23,7 @@
 			Radio4000Player
 		},
 		props: {
+			autoplay: Boolean,
 			channelSlug: String,
 			channelId: String,
 			trackId: String,

--- a/src/ProviderPlayer.vue
+++ b/src/ProviderPlayer.vue
@@ -4,6 +4,7 @@
 		<youtube-player
 				v-if="provider === 'youtube'"
 				:volume="volume"
+				:autoplay="autoplay"
 				:trackId="track.ytid"
 				:isPlaying="isPlaying"
 				:isMuted="isMuted"

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -9,11 +9,11 @@
 
 		<aside>
 			<provider-player
-					:volume="volume"
-					:track="currentTrack"
+					:autoplay="autoplay"
 					:isPlaying="isPlaying"
 					:isMuted="isMuted"
-					:autoplay="autoplay"
+					:track="currentTrack"
+					:volume="volume"
 					@play="play"
 					@pause="pause"
 					@playNextTrack="playNextTrack"></provider-player>
@@ -63,6 +63,7 @@
 			PlayerControls
 		},
 		props: {
+			autoplay: Boolean,
 			channel: Object,
 			tracks: Array,
 			track: Object,
@@ -74,7 +75,6 @@
 		data () {
 			return {
 				playerReady: false,
-				autoplay: false,
 				loop: false,
 				isPlaying: false,
 				isMuted: false,

--- a/src/YoutubePlayer.vue
+++ b/src/YoutubePlayer.vue
@@ -17,6 +17,7 @@
 	export default {
 		name: 'youtube-player',
 		props: [
+			'autoplay',
 			'volume',
 			'isPlaying',
 			'isMuted',
@@ -33,7 +34,8 @@
 					playsinline: 1,
 					rel: 0,
 					showinfo: 0
-				}
+				},
+				didPlay: false
 			}
 		},
 		mounted() {
@@ -130,11 +132,15 @@
 			},
 
 			// select track to play
-			setTrackOnProvider(trackId) {
-				if (!trackId) return
-				this.player.loadVideoById({
-					'videoId': trackId
-				}).then(this.playProvider())
+			setTrackOnProvider(videoId) {
+				if (!videoId) return
+				if (this.autoplay || this.didPlay) {
+					// The extra .then -> play here is to autoplay on mobile.
+					this.player.loadVideoById({videoId}).then(this.playProvider)
+				} else {
+					this.player.cueVideoById({videoId})
+					this.didPlay = true
+				}
 			},
 			playProvider() {
 				this.player.playVideo()

--- a/test/youtube-player.js
+++ b/test/youtube-player.js
@@ -2,12 +2,22 @@ import test from 'ava'
 import Vue from 'vue'
 import Component from '../src/YoutubePlayer.vue'
 
-test('renders', t => {
+test.cb('renders', t => {
 	const vm = new Vue(Component).$mount()
 	const tree = {
 		$el: vm.$el.outerHTML
 	}
-	t.snapshot(tree)
 	const $ = selector => vm.$el.querySelectorAll(selector)
-	t.is($('.ytplayer').length, 1, 'it has an empty element for the yt player to replace')
+
+	t.snapshot(tree)
+
+	t.is($('.ytplayer').length, 1, 'has an element for the youtube iframe')
+	t.is(vm.$props.autoplay, undefined, 'autoplay is not enabled')
+
+	t.is(vm.$data.didPlay, false)
+	vm.$props.trackId = '-Op4D4bkK6Y'
+	vm.$nextTick(() => {
+		t.is(vm.$data.didPlay, true, 'after playing, didPlay changes to true')
+		t.end()
+	})
 })


### PR DESCRIPTION
Adds new `autoplay` which can be set directly on the player.

It is then passed all the way down to `youtube-player` which decides whether to use `loadVideoById` or `cueVideoById`. Any new plays after that will always load.