### PR TITLE
feature/adapter start by track + works on r4

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,9 @@
 
 	<!-- there are three different ways to start the player -->
 	<div class="Grid">
-		<radio4000-player channel-slug="200ok"></radio4000-player>
+		<!-- <radio4000-player channel-slug="200ok"></radio4000-player> -->
 		<!-- <radio4000-player channel-id=""></radio4000-player> -->
-		<!-- <radio4000-player track-id="-JYZvhj3vlGCjKXZ2cXO"></radio4000-player> -->
+		<radio4000-player track-id="-KdVUsr70yYdIoBDmL43"></radio4000-player>
 	</div>
 
 	<div class="Grid">

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 		<!-- <radio4000-player channel-slug="200ok"></radio4000-player> -->
 		<!-- <radio4000-player channel-id=""></radio4000-player> -->
 		<radio4000-player track-id="-KdVUsr70yYdIoBDmL43"></radio4000-player>
+		<!-- <radio4000-player autoplay="true"></radio4000-player> -->
 	</div>
 
 	<div class="Grid">

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -1,21 +1,19 @@
 <template>
-	<article>
-		<radio4000-player
-				v-if="playerStarted"
-				:channel="channel"
-				:tracks="tracks"
-				:track="track"
-				:image="image"
-				:autoplay="autoplay"
-				:showCurrentTrack="showCurrentTrack"
-				:showTracks="showTracks"
-				:volume="volume"/>
-		<div v-else class="Console">
-			<p>Radio4000-player is ready to start playing data:
-				<a href="https://github.com/internet4000/radio4000-player-vue">documentation</a>
-			</p>
-		</div>
-	</article>
+	<radio4000-player
+			v-if="playerStarted"
+			:channel="channel"
+			:tracks="tracks"
+			:track="track"
+			:image="image"
+			:autoplay="autoplay"
+			:showCurrentTrack="showCurrentTrack"
+			:showTracks="showTracks"
+			:volume="volume"/>
+	<div v-else class="Console">
+		<p>Radio4000-player is ready to start playing data:
+			<a href="https://github.com/internet4000/radio4000-player-vue">documentation</a>
+		</p>
+	</div>
 </template>
 
 <script>

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -73,7 +73,7 @@
 			
 			if (trackId) {
 				return this.loadTrack(trackId)
-									 .then(track => this.loadChannelById(track.channel))
+					.then(track => this.loadChannelById(track.channel))
 			}
 			
 			if (channelSlug) {

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -6,7 +6,6 @@
 			:track="track"
 			:image="image"
 			:autoplay="autoplay"
-			:showCurrentTrack="showCurrentTrack"
 			:showTracks="showTracks"
 			:volume="volume"/>
 	<div v-else class="Console">
@@ -41,10 +40,6 @@
 			showTracks: {
 				type: Boolean,
 				default: true
-			},
-			showCurrentTrack: {
-				type: Boolean,
-				default: false
 			}
 		},
 		data () {

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -123,7 +123,7 @@
 				this.playerStarted = true;
 				findChannelTracks(channel.id)
 					.then(this.updatePlayerWithTracks)
-					.then(findChannelImage(channel))
+				findChannelImage(channel)
 					.then(this.updatePlayerWithImage)
 			},
 			

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -6,8 +6,7 @@
 		:track="track"
 		:image="image"
 		:autoplay="autoplay"
-		:showTracks="showTracks"
-		:volume="volume"/>
+		:volume="volume" />
 	<div v-else class="Console">
 		<p>Radio4000-player is ready to start playing:
 			<a href="https://github.com/internet4000/radio4000-player-vue">documentation</a>
@@ -38,10 +37,6 @@
 			volume: {
 				type: Number,
 				default: 100
-			},
-			showTracks: {
-				type: Boolean,
-				default: true
 			}
 		},
 		data () {

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -17,11 +17,13 @@
 
 <script>
 	import Radio4000Player from './Radio4000Player.vue'
-	import { findChannelById,
-					 findChannelBySlug,
-					 findChannelTracks,
-					 findChannelImage,
-					 findTrack } from './store'
+	import {
+		findChannelById,
+		findChannelBySlug,
+		findChannelTracks,
+		findChannelImage,
+		findTrack
+	} from './store'
 
 	export default {
 		name: 'player-data',
@@ -43,7 +45,6 @@
 			}
 		},
 		data () {
-			/* return initialState()*/
 			return {
 				playerStarted: true,
 				channel: {},
@@ -55,16 +56,13 @@
 		},
 		created() {
 			const { channelSlug, channelId, trackId } = this;
-			
 			if (trackId) {
 				return this.loadTrack(trackId)
 					.then(track => this.loadChannelById(track.channel))
 			}
-			
 			if (channelSlug) {
 				return this.loadChannelBySlug(channelSlug)
 			}
-
 			if (channelId) {
 				return this.loadChannelById(channelId)
 			}
@@ -95,16 +93,6 @@
 			}
 		},
 		methods: {
-			clearR4Session() {
-				return new Promise((resolve, reject) => {
-					this.channel = {};
-					this.image = ''
-					this.tracks = []
-					this.track = {}
-					resolve()
-				})
-			},
-
 			// start player session by:
 			// all start method must return a `channel@r4` model
 			loadChannelBySlug(slug) {
@@ -122,29 +110,22 @@
 				findChannelImage(channel)
 					.then(this.updatePlayerWithImage)
 			},
-			
 			loadTrack(trackId) {
 				return findTrack(trackId).then(this.updatePlayerWithTrack)
 			},
-			startSessionFirstTrack(channel) {
-				var len = channel.tracks.length -1
-				return loadTrack(channel.tracks[len])
-			},
-
 			updatePlayerWithChannel(channel) {
-				if(channel.id === this.channel.id) return
-			
-				this.channel = channel;
+				if (channel.id === this.channel.id) return
+				this.channel = channel
 				this.loadChannelExtra(this.channel)
 			},
 			updatePlayerWithTrack(track) {
 				return this.track = track
 			},
 			updatePlayerWithTracks(tracks) {
-				this.tracks = tracks;
+				return this.tracks = tracks
 			},
 			updatePlayerWithImage(image) {
-				this.image = image ? image.src : ''
+				return this.image = image ? image.src : ''
 			}
 		}
 	}

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -56,20 +56,12 @@
 				channel: {},
 				image: '',
 				tracks: [],
-				track: {}
+				track: {},
+				providerTrack: {}
 			}
 		},
 		created() {
-			// init 1 - if there is any following key,
-			// start the according session
-			// otherwise stay in idle mode
 			const { channelSlug, channelId, trackId } = this;
-
-			if (!channelSlug && !channelId && !trackId ) {
-				return this.playerStarted = false;
-			}
-
-			this.playerStarted = true;
 			
 			if (trackId) {
 				return this.loadTrack(trackId)
@@ -85,9 +77,6 @@
 			}
 		},
 		watch: {
-			// init 1 bis,
-			// `slug` and `id` are only used to assign radio externally
-			// by the <radio4000-player> web component props
 			channelSlug: function (slug) {
 				this.loadChannelBySlug(slug)				
 			},
@@ -96,6 +85,20 @@
 			},
 			trackId: function (id) {
 				this.loadTrack(id).then(track => this.loadChannelById(track.channel))
+			},
+			providerTrack: function(track) {
+				console.log("track", track)
+			}
+		},
+		computed: {
+			playerStarted: function() {
+				const { channelSlug, channelId, trackId } = this;
+
+				if (!channelSlug && !channelId && !trackId ) {
+					return false;
+				}
+				
+				return true;
 			}
 		},
 		methods: {

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -1,15 +1,15 @@
 <template>
 	<radio4000-player
-			v-if="playerStarted"
-			:channel="channel"
-			:tracks="tracks"
-			:track="track"
-			:image="image"
-			:autoplay="autoplay"
-			:showTracks="showTracks"
-			:volume="volume"/>
+		v-if="canLoad"
+		:channel="channel"
+		:tracks="tracks"
+		:track="track"
+		:image="image"
+		:autoplay="autoplay"
+		:showTracks="showTracks"
+		:volume="volume"/>
 	<div v-else class="Console">
-		<p>Radio4000-player is ready to start playing data:
+		<p>Radio4000-player is ready to start playing:
 			<a href="https://github.com/internet4000/radio4000-player-vue">documentation</a>
 		</p>
 	</div>
@@ -46,7 +46,6 @@
 		},
 		data () {
 			return {
-				playerStarted: true,
 				channel: {},
 				image: '',
 				tracks: [],
@@ -82,14 +81,8 @@
 			}
 		},
 		computed: {
-			playerStarted: function() {
-				const { channelSlug, channelId, trackId } = this;
-
-				if (!channelSlug && !channelId && !trackId ) {
-					return false;
-				}
-				
-				return true;
+			canLoad: function() {
+				return this.channelSlug || this.channelId || this.trackId 
 			}
 		},
 		methods: {
@@ -104,7 +97,6 @@
 					.then(this.updatePlayerWithChannel)
 			},
 			loadChannelExtra(channel) {
-				this.playerStarted = true;
 				findChannelTracks(channel.id)
 					.then(this.updatePlayerWithTracks)
 				findChannelImage(channel)
@@ -134,7 +126,7 @@
 <style>
 	.Console {
 		font-family: monospace;
-		padding: 0.5rem;
+		padding: 0 1rem;
 		line-height: 1.4;
 	}
 </style>

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -69,6 +69,8 @@
 				return this.playerStarted = false;
 			}
 
+			this.playerStarted = true;
+			
 			if (trackId) {
 				return this.loadTrack(trackId)
 									 .then(track => this.loadChannelById(track.channel))
@@ -118,6 +120,7 @@
 					.then(this.updatePlayerWithChannel)
 			},
 			loadChannelExtra(channel) {
+				this.playerStarted = true;
 				findChannelTracks(channel.id)
 					.then(this.updatePlayerWithTracks)
 					.then(findChannelImage(channel))

--- a/src/ProviderPlayer.vue
+++ b/src/ProviderPlayer.vue
@@ -2,15 +2,15 @@
 	<div class="ProviderPlayer">
 		<div class="Ratio"></div>
 		<youtube-player
-				v-if="provider === 'youtube'"
-				:volume="volume"
-				:autoplay="autoplay"
-				:trackId="track.ytid"
-				:isPlaying="isPlaying"
-				:isMute="isMute"
-				@play="playProvider"
-				@pause="pauseProvider"
-				@trackEnded="trackEnded"></youtube-player>
+			v-if="provider === 'youtube'"
+			:volume="volume"
+			:autoplay="autoplay"
+			:videoId="track.ytid"
+			:isPlaying="isPlaying"
+			:isMute="isMute"
+			@play="playProvider"
+			@pause="pauseProvider"
+			@trackEnded="trackEnded"></youtube-player>
 	</div>
 </template>
 
@@ -23,30 +23,18 @@
 			YoutubePlayer
 		},
 		props: [
-			'videoId',
 			'volume',
 			'autoplay',
 			'isPlaying',
 			'isMute',
 			'track'
 		],
-		data() {
-			return {
-				provider: ''
-			}
-		},
-		watch: {
-			track: function(track) {
-				if (!track) return
-				this.selectProvider(track)
+		computed: {
+			provider: function() {
+				return this.track.ytid ? 'youtube' : undefined
 			}
 		},
 		methods: {
-			selectProvider(track) {
-				if (track.ytid) {
-					this.provider = 'youtube'
-				}
-			},
 			playProvider() {
 				this.$emit('play');
 			},

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -19,11 +19,6 @@
 				@playNextTrack="playNextTrack"></provider-player>
 		</aside>
 
-		<main v-if="showTrack">
-			<track-current
-					:track="currentTrack"></track-current>
-		</main>
-
 		<main v-if="showTracks">
 			<track-list
 					:tracks="tracksPool"
@@ -71,7 +66,6 @@
 			tracks: Array,
 			track: Object,
 			image: String,
-			showCurrentTrack: Boolean,
 			showTracks: Boolean,
 			volume: Number
 		},
@@ -217,4 +211,3 @@
 		fill: hsla(0, 0%, 100%, 0.3);
 	}
 </style>
-

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -14,7 +14,6 @@
 					:autoplay="autoplay"
 					:isPlaying="isPlaying"
 					:isMute="isMute"
-					:autoplay="autoplay"
 					@play="play"
 					@pause="pause"
 					@playNextTrack="playNextTrack"></provider-player>

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -19,7 +19,7 @@
 				@playNextTrack="playNextTrack"></provider-player>
 		</aside>
 
-		<main v-if="showTracks">
+		<main>
 			<track-list
 				:tracks="tracksPool"
 				:track="currentTrack"
@@ -61,12 +61,11 @@
 			PlayerControls
 		},
 		props: {
-			autoplay: Boolean,
 			channel: Object,
 			tracks: Array,
 			track: Object,
 			image: String,
-			showTracks: Boolean,
+			autoplay: Boolean,
 			volume: Number
 		},
 		data () {

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -9,14 +9,14 @@
 
 		<aside>
 			<provider-player
-					:volume="volume"
-					:track="currentTrack"
-					:autoplay="autoplay"
-					:isPlaying="isPlaying"
-					:isMute="isMute"
-					@play="play"
-					@pause="pause"
-					@playNextTrack="playNextTrack"></provider-player>
+				:volume="volume"
+				:track="currentTrack"
+				:autoplay="autoplay"
+				:isPlaying="isPlaying"
+				:isMute="isMute"
+				@play="play"
+				@pause="pause"
+				@playNextTrack="playNextTrack"></provider-player>
 		</aside>
 
 		<main v-if="showTrack">
@@ -85,6 +85,9 @@
 				currentTrack: {},
 				tracksPool: []
 			}
+		},
+		created() {
+			if (this.track) this.playTrack(this.track)
 		},
 		computed: {
 			isNotFullVolume: function() {

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -2,9 +2,9 @@
 	<article class="Player">
 		<header>
 			<channel-header
-					:channel="channel"
-					:image="image"
-					:track="currentTrack"></channel-header>
+				:channel="channel"
+				:image="image"
+				:track="currentTrack"></channel-header>
 		</header>
 
 		<aside>
@@ -21,25 +21,25 @@
 
 		<main v-if="showTracks">
 			<track-list
-					:tracks="tracksPool"
-					:track="currentTrack"
-					:currentTrackIndex="currentTrackIndex"
-					@select="playTrack"></track-list>
+				:tracks="tracksPool"
+				:track="currentTrack"
+				:currentTrackIndex="currentTrackIndex"
+				@select="playTrack"></track-list>
 		</main>
 
 		<footer>
 			<player-controls
-					:isPlaying="isPlaying"
-					:volume="volume"
-					:isDisabled="!this.tracksPool.length"
-					:isNotFullVolume="isNotFullVolume"
-					:isMute="isMute"
-					:isShuffle="isShuffle"
-					@play="play"
-					@pause="pause"
-					@toggleMute="toggleMute"
-					@toggleShuffle="toggleShuffle"
-					@next="playNextTrack"></player-controls>
+				:isPlaying="isPlaying"
+				:volume="volume"
+				:isDisabled="!this.tracksPool.length"
+				:isNotFullVolume="isNotFullVolume"
+				:isMute="isMute"
+				:isShuffle="isShuffle"
+				@play="play"
+				@pause="pause"
+				@toggleMute="toggleMute"
+				@toggleShuffle="toggleShuffle"
+				@next="playNextTrack"></player-controls>
 		</footer>
 	</article>
 </template>
@@ -93,13 +93,13 @@
 		},
 		watch: {
 			track: function(track) {
-				this.playTrack(track);
+				this.playTrack(track)
 			},
 			tracks: function(tracks) {
-				this.newTracksPool();
+				this.newTracksPool()
 			},
 			volume: function(volume) {
-				if(volume <= 0) {
+				if (volume <= 0) {
 					this.mute()
 				}
 				this.unMute();
@@ -107,16 +107,16 @@
 		},
 		methods: {
 			playTrack(track) {
-				this.currentTrack = track;
+				this.currentTrack = track
 			},
 			newTracksPool() {
-				var newTracksPool = this.tracks.slice().reverse();
-				if(this.isShuffle) {
+				var newTracksPool = this.tracks.slice().reverse()
+				if (this.isShuffle) {
 					const currentTrackArray = newTracksPool.splice(this.currentTrackIndex, 1)
 					const shuffledArray = shuffleArray(newTracksPool);
 					this.tracksPool = [...currentTrackArray, ...shuffledArray]
 				} else {
-					this.tracksPool = newTracksPool;
+					this.tracksPool = newTracksPool
 				}
 			},
 			playNextTrack() {
@@ -128,7 +128,7 @@
 			},
 			getNextTrack() {
 				const pool = this.tracksPool
-				const index = this.currentTrackIndex;
+				const index = this.currentTrackIndex
 				return pool[index + 1]
 			},
 			play() {
@@ -138,19 +138,19 @@
 				this.isPlaying = false;
 			},
 			toggleMute() {
-				if(this.isMute) {
+				if (this.isMute) {
 					this.isMute = false
 				} else {
 					this.isMute = true
 				}
 			},
 			toggleShuffle() {
-				if(this.isShuffle) {
+				if (this.isShuffle) {
 					this.isShuffle = false
 				} else {
 					this.isShuffle = true
 				}
-				this.newTracksPool();
+				this.newTracksPool()
 			}
 		}
 	}

--- a/src/YoutubePlayer.vue
+++ b/src/YoutubePlayer.vue
@@ -21,7 +21,7 @@
 			'volume',
 			'isPlaying',
 			'isMute',
-			'trackId'
+			'videoId'
 		],
 		data() {
 			return {
@@ -39,27 +39,27 @@
 			}
 		},
 		mounted() {
-			if (this.trackId) {
-				this.initPlayer().then(this.setTrackOnProvider(this.trackId))
+			if (this.videoId) {
+				this.initPlayer().then(this.setTrackOnProvider(this.videoId))
 			}
 		},
 		watch: {
-			trackId(trackId) {
-				this.initPlayer().then(this.setTrackOnProvider(trackId))
+			videoId(videoId) {
+				this.initPlayer().then(this.setTrackOnProvider(videoId))
 			},
 			isPlaying(isPlaying) {
 				if (!this.player) return
 				if (isPlaying) {
-					this.playProvider();
+					this.playProvider()
 				} else {
-					this.pauseProvider();
+					this.pauseProvider()
 				}
 			},
 			isMute(isMute) {
 				if (isMute && this.playerExists) {
 					this.muteProvider()
 				} else {
-					this.unMuteProvider();
+					this.unMuteProvider()
 				}
 			}
 		},

--- a/src/store.js
+++ b/src/store.js
@@ -24,10 +24,9 @@ export function findTrack(id) {
 export function findChannelImage(channel) {
 	// If there's an image, fetch and embed it on the channel.
 	// This can be removed once new r4 api is deployed.
+	if (!channel || !channel.images) return
+
 	const imageId = Object.keys(channel.images)[0]
-	if (!imageId) {
-		return
-	}
 	return findImage(imageId);
 }
 

--- a/test/youtube-player.js
+++ b/test/youtube-player.js
@@ -15,7 +15,7 @@ test.cb('renders', t => {
 	t.is(vm.$props.autoplay, undefined, 'autoplay is not enabled')
 
 	t.is(vm.$data.didPlay, false)
-	vm.$props.trackId = '-Op4D4bkK6Y'
+	vm.$props.videoId = '-Op4D4bkK6Y'
 	vm.$nextTick(() => {
 		t.is(vm.$data.didPlay, true, 'after playing, didPlay changes to true')
 		t.end()


### PR DESCRIPTION
Updated the `playerData` adapter, providing the player with data from radio4000.

- [x] start by track does not fetch channel if it hasn't changed 
- [ ] make it working integrated as the player on r4.com
- [ ] refactor overall aspect for future `providers`
