### PR TITLE
make URLs work internally to r4

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ If you're familiar with CSS, you can also write your own styles targeting the `<
 </style>
 ```
 
+## More
+
+If this player is used inside radio4000.com, we want the links to switch URL internally.
+For that you can use the boolean property `r4-url` like so.
+```
+<radio4000-player r4-url="true"></radio4000-player>
+```
+Therefore, URLs in the player header won't open new browser window but will just remplace the URL like Ember router would have done.
+
 ## Development
 
 ``` bash

--- a/src/ChannelHeader.vue
+++ b/src/ChannelHeader.vue
@@ -1,7 +1,6 @@
 <template>
 	<div class="Header">
 		<a :href="href"
-			 target="_blank"
 			 title="Check this radio on Radio4000"
 			 class="Header-image">
 			<img v-if="image" :src="image" alt="">
@@ -31,11 +30,21 @@
 	import Loading from './Loading.vue'
 	export default {
 		name: 'channel-header',
-		props: ['channel', 'track', 'image'],
+		props: [
+			'channel',
+			'track',
+			'image',
+			'r4Url'],
 		components: { Loading },
 		computed: {
 			href: function () {
-				const root = 'https://radio4000.com/'
+				let root;
+				if(this.r4Url) {
+					root = '/'
+				} else {
+					root = 'https://radio4000.com/'
+				}
+				
 				return this.channel.slug === undefined ? root : root + this.channel.slug
 			}
 		}

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -1,12 +1,13 @@
 <template>
 	<radio4000-player
-		v-if="canLoad"
-		:channel="channel"
-		:tracks="tracks"
-		:track="track"
-		:image="image"
-		:autoplay="autoplay"
-		:volume="volume" />
+			v-if="canLoad"
+			:channel="channel"
+			:tracks="tracks"
+			:track="track"
+			:image="image"
+			:autoplay="autoplay"
+			:r4Url="r4Url"
+			:volume="volume" />
 	<div v-else class="Console">
 		<p>Radio4000-player is ready to start playing:
 			<a href="https://github.com/internet4000/radio4000-player-vue">documentation</a>
@@ -34,6 +35,10 @@
 			channelSlug: String,
 			channelId: String,
 			trackId: String,
+			r4Url: {
+				type: Boolean,
+				default: false
+			},
 			volume: {
 				type: Number,
 				default: 100

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -2,44 +2,45 @@
 	<article class="Player">
 		<header>
 			<channel-header
-				:channel="channel"
-				:image="image"
-				:track="currentTrack"></channel-header>
+:r4Url="r4Url"
+:channel="channel"
+:image="image"
+:track="currentTrack"></channel-header>
 		</header>
 
 		<aside>
 			<provider-player
-				:volume="volume"
-				:track="currentTrack"
-				:autoplay="autoplay"
-				:isPlaying="isPlaying"
-				:isMuted="isMuted"
-				@play="play"
-				@pause="pause"
-				@playNextTrack="playNextTrack"></provider-player>
+:volume="volume"
+:track="currentTrack"
+:autoplay="autoplay"
+:isPlaying="isPlaying"
+:isMuted="isMuted"
+@play="play"
+@pause="pause"
+@playNextTrack="playNextTrack"></provider-player>
 		</aside>
 
 		<main>
 			<track-list
-				:tracks="tracksPool"
-				:track="currentTrack"
-				:currentTrackIndex="currentTrackIndex"
-				@select="playTrack"></track-list>
+:tracks="tracksPool"
+:track="currentTrack"
+:currentTrackIndex="currentTrackIndex"
+@select="playTrack"></track-list>
 		</main>
 
 		<footer>
 			<player-controls
-				:isPlaying="isPlaying"
-				:volume="volume"
-				:isDisabled="!this.tracksPool.length"
-				:isNotFullVolume="isNotFullVolume"
-				:isMuted="isMuted"
-				:isShuffle="isShuffle"
-				@play="play"
-				@pause="pause"
-				@toggleMute="toggleMute"
-				@toggleShuffle="toggleShuffle"
-				@next="playNextTrack"></player-controls>
+:isPlaying="isPlaying"
+:volume="volume"
+:isDisabled="!this.tracksPool.length"
+:isNotFullVolume="isNotFullVolume"
+:isMuted="isMuted"
+:isShuffle="isShuffle"
+@play="play"
+@pause="pause"
+@toggleMute="toggleMute"
+@toggleShuffle="toggleShuffle"
+@next="playNextTrack"></player-controls>
 		</footer>
 	</article>
 </template>
@@ -66,6 +67,7 @@
 			track: Object,
 			image: String,
 			autoplay: Boolean,
+			r4Url: Boolean,
 			volume: Number
 		},
 		data () {


### PR DESCRIPTION
When clicking the player header `channel.img` it used to open a new tab to this radio channel on radio4000.com.

Now with the `r4Url` boolean as a property on the `<radio4000-player>` html element, the URL will update internally to r4 when the player is inside r4 ofc