### PR TITLE
Feature/allow shuffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Here's a list of all the attributes you can set and change on the web component.
 - `channel-slug` [string], a radio4000 channel slug (ex: `oskar`)
 - `channel-id` [string], a radio4000 channel id (ex: `-JYZvhj3vlGCjKXZ2cXO`)
 - `track-id` [string], a radio4000 track id (ex: `-JYEosmvT82Ju0vcSHVP`)
-- `volume` [integer] from 0 to 100
-- `autoplay` [boolean], if it should start playing automatically
+- `volume` [integer] from 0 to 100 (default: `100`)
+- `autoplay` [boolean], if it should start playing automatically (default: `false`)
+- `shuffle` [boolean], if tracks should be shuffled (default: `false`)
 
 ### Examples
 
@@ -41,6 +42,9 @@ player.trackId = '-JYEosmvT82Ju0vcSHVP'
 
 // Change the volume.
 player.volume = 25
+
+// Enable shuffle.
+player.shuffle = true
 ```
 
 To enable autoplay:

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
 	<title>Radio4000 player</title>
 </head>
 <body>
-	<radio4000-player track-id="-KdVUsr70yYdIoBDmL43"></radio4000-player>
+	<!--<radio4000-player track-id="-KdVUsr70yYdIoBDmL43"></radio4000-player>-->
+	<radio4000-player channel-slug="200ok"></radio4000-player> 
+	<radio4000-player channel-slug="200ok" shuffle="true"></radio4000-player> 
 
 	<!-- development script-->
 	<script async src="dist/radio4000-player.js"></script>
@@ -17,9 +19,7 @@
 	<!-- cdn url from the production version from github master-->
 	<!-- <script src="https://rawgit.com/internet4000/radio4000-player-vue/master/dist/radio4000-player.min.js" async></script> -->
 
-	<!-- Three ways to start the player -->
 	<div class="Grid">
-		<!-- <radio4000-player channel-slug="200ok"></radio4000-player> -->
 		<!-- <radio4000-player channel-id=""></radio4000-player> -->
 		<!-- <radio4000-player autoplay="true"></radio4000-player> -->
 	</div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<title>Radio4000 player</title>
 </head>
 <body>
-	<!--<radio4000-player track-id="-KdVUsr70yYdIoBDmL43"></radio4000-player>-->
+	<radio4000-player track-id="-KdVUsr70yYdIoBDmL43"></radio4000-player>
 	<radio4000-player channel-slug="200ok"></radio4000-player> 
 	<radio4000-player channel-slug="200ok" shuffle="true"></radio4000-player> 
 

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -7,7 +7,8 @@
 			:image="image"
 			:autoplay="autoplay"
 			:r4Url="r4Url"
-			:volume="volume" />
+			:volume="volume"
+			:shuffle="shuffle" />
 	<div v-else class="Console">
 		<p>Radio4000-player is ready to start playing:
 			<a href="https://github.com/internet4000/radio4000-player-vue">documentation</a>
@@ -42,7 +43,8 @@
 			volume: {
 				type: Number,
 				default: 100
-			}
+			},
+			shuffle: Boolean
 		},
 		data () {
 			return {

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -83,7 +83,9 @@
 			}
 		},
 		created() {
-			if (this.track) this.playTrack(this.track)
+			if (Object.keys(this.track).length !== 0) {
+				this.playTrack(this.track)
+			} 
 		},
 		computed: {
 			isNotFullVolume: function() {
@@ -102,6 +104,9 @@
 			},
 			tracks: function(tracks) {
 				this.newTracksPool()
+
+				const noTrack = Object.keys(this.currentTrack).length === 0
+				if (noTrack) this.playNextTrack()
 			},
 			volume: function(volume) {
 				if (volume <= 0) {

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -68,6 +68,7 @@
 			image: String,
 			autoplay: Boolean,
 			r4Url: Boolean,
+			shuffle: Boolean,
 			volume: Number
 		},
 		data () {
@@ -76,7 +77,7 @@
 				loop: false,
 				isPlaying: false,
 				isMuted: false,
-				isShuffle: false,
+				isShuffle: this.$props.shuffle,
 				currentTrack: {},
 				tracksPool: []
 			}
@@ -93,6 +94,9 @@
 			}
 		},
 		watch: {
+			shuffle: function(shuffle) {
+				this.isShuffle = shuffle
+			},
 			track: function(track) {
 				this.playTrack(track)
 			},


### PR DESCRIPTION
See #33.

Allow for shuffle to be set externally like `<radio400-player shuffle="true">`. By default it is not enabled. If it is enabled, it will enable shuffle (internally).

It will also cue the first track from the pool. By default, this will be the newest track. With shuffle, it will be the first in the shuffled tracks pool.

If a `track-id` is specfified it will cue that track, whether shuffle is enabled or not.

Note: I had to do some nasty checks for checking empty objects because we set our data like `data = {currentTrack: {}}`.