### PR TITLE
Add track events

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ You can listen for events directly on each `<radio4000-player>` element.
 ### Supported events
 
 - `trackChanged` - This event fires whenever the current track is changed.
+- `trackEnded` - This event fires when the current track finishes playing.
 
-Here's an example of how to listen for the `trackChanged` event. The `event.detail` argument will be a Radio4000 `track` object.
+Here's an example of how to listen for the `trackChanged` event. It is the same approach for all events. In the case of both `trackChanged` and `trackEnded`, the `event.detail` argument will be a Radio4000 `track` object.
 
 ```js
 var player = document.querySelector('radio4000-player')

--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ To enable autoplay:
 <radio4000-player channel-slug="200ok" autoplay="true"></radio4000-player>
 ```
 
+## Events
+
+You can listen for events directly on each `<radio4000-player>` element.
+
+### Supported events
+
+- `trackChanged` - This event fires whenever the current track is changed.
+
+Here's an example of how to listen for the `trackChanged` event. The `event.detail` argument will be a Radio4000 `track` object.
+
+```js
+var player = document.querySelector('radio4000-player')
+player.addEventListener('trackChanged', (event) => {
+	console.info('trackChanged event', event.detail)
+})
+```
+
 ## Skins
 
 We offer a dark skin and a mini one. To use, add or combine the classes. Here are some examples:

--- a/index.html
+++ b/index.html
@@ -12,6 +12,13 @@
 	<!-- <radio4000-player channel-slug="200ok"></radio4000-player> -->
 	<radio4000-player channel-id="-KFzPXLNzmKjPGwyY-xx"></radio4000-player>
 
+	<script>
+		var player = document.querySelector('radio4000-player')
+		player.addEventListener('trackChanged', (event) => {
+			console.info('[event:trackChanged]', event.detail)
+		})
+	</script>
+
 	<!-- Skin tests -->	
 	<!-- <div class="Grid">
 		<radio4000-player channel-slug="200ok" class="dark"></radio4000-player>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
 		player.addEventListener('trackChanged', (event) => {
 			console.info('[event:trackChanged]', event.detail)
 		})
+		player.addEventListener('trackEnded', (event) => {
+			console.info('[event:trackEnded]', event.detail)
+		})
 	</script>
 
 	<!-- Skin tests -->	

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -10,6 +10,7 @@
 			:volume="volume"
 			:shuffle="shuffle"
 			@trackChanged="onTrackChanged"	
+			@trackEnded="onTrackEnded"	
 	 ></radio4000-player>
 	<div v-else class="Console">
 		<p>Radio4000-player is ready to start playing:
@@ -124,8 +125,10 @@
 				return this.image = image ? image : ''
 			},
 			onTrackChanged(...args) {
-				console.log('track changed:', ...args)
 				this.$emit('trackChanged', ...args)
+			},
+			onTrackEnded(...args) {
+				this.$emit('trackEnded', ...args)
 			}
 		}
 	}

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -8,7 +8,9 @@
 			:autoplay="autoplay"
 			:r4Url="r4Url"
 			:volume="volume"
-			:shuffle="shuffle" />
+			:shuffle="shuffle"
+			@trackChanged="onTrackChanged"	
+	 ></radio4000-player>
 	<div v-else class="Console">
 		<p>Radio4000-player is ready to start playing:
 			<a href="https://github.com/internet4000/radio4000-player-vue">documentation</a>
@@ -120,6 +122,10 @@
 			},
 			updatePlayerWithImage(image) {
 				return this.image = image ? image : ''
+			},
+			onTrackChanged(...args) {
+				console.log('track changed:', ...args)
+				this.$emit('trackChanged', ...args)
 			}
 		}
 	}

--- a/src/ProviderPlayer.vue
+++ b/src/ProviderPlayer.vue
@@ -50,7 +50,7 @@
 				this.$emit('unMute')
 			},
 			trackEnded() {
-				this.$emit('playNextTrack')
+				this.$emit('trackEnded')
 			}
 		}
 }

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -17,7 +17,7 @@
 :isMuted="isMuted"
 @play="play"
 @pause="pause"
-@playNextTrack="playNextTrack"></provider-player>
+@trackEnded="playNextTrack"></provider-player>
 		</aside>
 
 		<main>
@@ -85,7 +85,7 @@
 		created() {
 			if (Object.keys(this.track).length !== 0) {
 				this.playTrack(this.track)
-			} 
+			}
 		},
 		computed: {
 			isNotFullVolume: function() {
@@ -118,6 +118,7 @@
 		methods: {
 			playTrack(track) {
 				this.currentTrack = track
+				this.$emit('trackChanged', track)
 			},
 			newTracksPool() {
 				var newTracksPool = this.tracks.slice().reverse()

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -17,7 +17,7 @@
 :isMuted="isMuted"
 @play="play"
 @pause="pause"
-@trackEnded="playNextTrack"></provider-player>
+@trackEnded="trackEnded"></provider-player>
 		</aside>
 
 		<main>
@@ -152,6 +152,10 @@
 			toggleShuffle() {
 				this.isShuffle = !this.isShuffle
 				this.newTracksPool()
+			},
+			trackEnded() {
+				this.$emit('trackEnded', this.track)
+				this.playNextTrack()
 			}
 		}
 	}


### PR DESCRIPTION
This adds a `trackChanged` event which you can listen to using normal JavaScript.

Example:

```js
var player = document.querySelector('radio4000-player')
player.addEventListener('trackChanged', (event) => {
  console.info('the track changed!', event.detail)
})
```

The `event.detail` is where our argument to the event is. I'm passing it the R4 track object atm.

It is fired when a track is changed and NOT when it ends. This means it fires:

- once on load when a track is cued
- when you press "next"
- when it automatically plays next track
- etc