### PR TITLE
Feature/responsive-with-js

### DIFF
--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -9,6 +9,7 @@
 		:r4Url="r4Url"
 		:volume="localVolume"
 		:shuffle="shuffle"
+		@resize="onResize"
 		@trackChanged="onTrackChanged"
 		@trackEnded="onTrackEnded">
 		<!-- {{volume}} <input type="range" v-model="localVolume">  -->
@@ -141,6 +142,9 @@
 			},
 			onTrackEnded(...args) {
 				this.$emit('trackEnded', ...args)
+			},
+			onResize() {
+				console.log('resized')
 			}
 		}
 	}

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -130,7 +130,7 @@
 			handleResize: debounce(function() {
 				this.playerWidth = this.$root.$el.offsetWidth;
 				console.log(this.playerWidth)
-			}),
+			}, 400),
 
 			/* Play methods */
 			playTrack(track) {
@@ -186,7 +186,9 @@
 	radio4000-player {
 		box-sizing: border-box;
 	}
-	radio4000-player *, radio4000-player *:before, radio4000-player*:after {
+	radio4000-player *,
+	radio4000-player *:before,
+	radio4000-player *:after {
 		box-sizing: inherit;
 	}
 	radio4000-player {
@@ -196,13 +198,8 @@
 		font-family: 'maisonneue', 'system-ui', sans-serif;
 		background-color: hsl(260, 10%, 92% );
 		color: hsl(0, 0%, 10%);
-
-		/* Responsive scaling. A min. width of 352px is required to show YouTube volume. */
 		font-size: 1em;
 		width: 100%;
-		/* tests */
-		/*min-height: calc(2.75em + 200px + 2.6em);*/
-		/*height: 80vh;*/
 	}
 </style>
 

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -79,14 +79,14 @@
 			}
 		},
 		created() {
-			this.$root.$el.addEventListener('resize', this.handleResize());
+			this.$root.$el.addEventListener('resize', this.handleResize);
 			
 			if (Object.keys(this.track).length !== 0) {
 				this.playTrack(this.track)
 			}
 		},
 		destroyed() {
-			this.$root.$el.removeEventListener('resize', this.handleResize());
+			this.$root.$el.removeEventListener('resize', this.handleResize);
 		},
 		computed: {
 			isMuted: {

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="R4PlayerLayout">
+	<div class="R4PlayerLayout" :class="[isVertical ? 'R4PlayerLayout--vertical' : 'R4PlayerLayout--horizontal']">
 		<slot></slot>
 
 		<channel-header
@@ -74,13 +74,19 @@
 				isShuffle: this.$props.shuffle,
 				loop: false,
 				playerReady: false,
-				tracksPool: []
+				tracksPool: [],
+				elSize: null
 			}
 		},
 		created() {
+			this.addEventListeners();
+			
 			if (Object.keys(this.track).length !== 0) {
 				this.playTrack(this.track)
 			}
+		},
+		destroyed() {
+			this.removeEventListeners();
 		},
 		computed: {
 			isMuted: {
@@ -94,6 +100,10 @@
 						this.$root.$emit('setVolume', 100)
 					}
 				}
+			},
+			isVertical() {
+				console.log(this.elSize)
+				return this.elSize < 450;
 			},
 			currentTrackIndex() {
 				return this.tracksPool.findIndex(track => track.id === this.currentTrack.id)
@@ -114,6 +124,21 @@
 			}
 		},
 		methods: {
+			/* Responsive element */
+			addEventListeners() {
+				const $el = this.$root.$el;
+				window.addEventListener('resize', this.setElSize());
+			},
+			removeEventListeners() {
+				const $el = this.$root.$el;
+				window.removeEventListener('resize', this.setElSize());
+			},
+			setElSize() {
+				this.elSize = this.$root.$el.offsetWidth;
+				console.log(this.elSize)
+			},
+
+			/* Play methods */
 			playTrack(track) {
 				this.currentTrack = track
 				this.$emit('trackChanged', track)

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -129,7 +129,6 @@
 		methods: {
 			handleResize: debounce(function() {
 				this.playerWidth = this.$root.$el.offsetWidth;
-				console.log(this.playerWidth)
 			}, 400),
 
 			/* Play methods */

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -79,14 +79,14 @@
 			}
 		},
 		created() {
-			this.addEventListeners();
+			this.$root.$el.addEventListener('resize', this.handleResize());
 			
 			if (Object.keys(this.track).length !== 0) {
 				this.playTrack(this.track)
 			}
 		},
 		destroyed() {
-			this.removeEventListeners();
+			this.$root.$el.removeEventListener('resize', this.handleResize());
 		},
 		computed: {
 			isMuted: {
@@ -124,16 +124,7 @@
 			}
 		},
 		methods: {
-			/* Responsive element */
-			addEventListeners() {
-				const $el = this.$root.$el;
-				window.addEventListener('resize', this.setElSize());
-			},
-			removeEventListeners() {
-				const $el = this.$root.$el;
-				window.removeEventListener('resize', this.setElSize());
-			},
-			setElSize() {
+			handleResize() {
 				this.elSize = this.$root.$el.offsetWidth;
 				console.log(this.elSize)
 			},

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -43,6 +43,7 @@
 
 <script>
 	import Vue from 'vue'
+	import debounce from 'debounce'
 	import ChannelHeader from './ChannelHeader.vue'
 	import TrackList from './TrackList.vue'
 	import ProviderPlayer from './ProviderPlayer.vue'
@@ -75,18 +76,21 @@
 				loop: false,
 				playerReady: false,
 				tracksPool: [],
-				elSize: null
+				playerWidth: null,
+				playerBreakPoint: 600
 			}
 		},
 		created() {
-			this.$root.$el.addEventListener('resize', this.handleResize);
+			this.$nextTick(function() {
+				window.addEventListener('resize', this.handleResize);
+			})
 			
 			if (Object.keys(this.track).length !== 0) {
 				this.playTrack(this.track)
 			}
 		},
 		destroyed() {
-			this.$root.$el.removeEventListener('resize', this.handleResize);
+			window.removeEventListener('resize', this.handleResize);
 		},
 		computed: {
 			isMuted: {
@@ -102,8 +106,7 @@
 				}
 			},
 			isVertical() {
-				console.log(this.elSize)
-				return this.elSize < 450;
+				return this.playerWidth < this.playerBreakPoint;
 			},
 			currentTrackIndex() {
 				return this.tracksPool.findIndex(track => track.id === this.currentTrack.id)
@@ -124,10 +127,10 @@
 			}
 		},
 		methods: {
-			handleResize() {
-				this.elSize = this.$root.$el.offsetWidth;
-				console.log(this.elSize)
-			},
+			handleResize: debounce(function() {
+				this.playerWidth = this.$root.$el.offsetWidth;
+				console.log(this.playerWidth)
+			}),
 
 			/* Play methods */
 			playTrack(track) {
@@ -217,11 +220,9 @@
 		position: relative;
 		overflow: hidden;
 	}
-	@media screen and (min-width: 40rem) {
-		.Body {
-			flex-direction: row;
-			max-height: 80vh;
-		}
+	.R4PlayerLayout--horizontal .Body {
+		flex-direction: row;
+		max-height: 80vh;
 	}
 </style>
 

--- a/src/TrackList.vue
+++ b/src/TrackList.vue
@@ -56,10 +56,8 @@ export default {
 		min-width: 200px;
 		overflow: hidden;
 	}
-	@media screen and (min-width: 40rem) {
-		.TrackList {
-			max-width: 40rem;
-		}
+	.R4PlayerLayout--horizontal .TrackList {
+		max-width: 40rem;
 	}
 	.TrackList-list {
 		margin: 0;


### PR DESCRIPTION
This PR makes this component responsive **on its own size** (where media queries are dependant on the viewport size).

`playerBreakPoint` is set at `600`px, breakpoint switching one layout to the other.

An event listener sets the width of the player as `data`, a computed property toggles the following class:
- `R4PlayerLayout--vertical`
- `R4PlayerLayout--horizontal`

Then, css media queries are replaced by `.R4PlayerLayout--horizontal`.