### PR TITLE
Feature/flexbox no media query

### DIFF
--- a/src/ChannelHeader.vue
+++ b/src/ChannelHeader.vue
@@ -1,15 +1,15 @@
 <template>
 	<header class="Header">
-		<a :href="href" class="Header-image" :title="channelDescription">
+		<a :href="href" class="Header-media" :title="channelDescription">
 			<img v-if="image" :src="image" alt="">
 			<loading v-else/>
 		</a>
-		<div v-if="channel.title">
-			<p class="Header-title" :title="channelDescription"><strong>{{channel.title}}</strong></p>
-			<marquee class="Header-playing" :title="[track.body ? track.body : '']">{{track.title}}</marquee>
+		<div class="Header-body" v-if="channel.title">
+			<p class="Header-channel" :title="channelDescription"><strong>{{channel.title}}</strong></p>
+			<marquee class="Header-track" :title="[track.body ? track.body : '']">{{track.title}}</marquee>
 		</div>
 		<loading v-else/>
-		<a :href="href" target="_blank" title="Open this radio on Radio4000.com">
+		<a class="Header-logo" :href="href" target="_blank" title="Open this radio on Radio4000.com">
 			<R4Logo></R4Logo>
 		</a>
 	</header>
@@ -51,21 +51,29 @@
 		background-color: hsl(0, 0%, 96%);
 		border-bottom: 1px solid hsl(0, 0%, 60%);
 	}
-	.Header > div {
+	.Header-body {
 		flex: 1;
 		line-height: 1.4;
 	}
-	.Header-title {margin-left: 0.3em;}
-	.R4 {
+	.Header-channel {
+		font-size: 0.9rem;
+		margin-left: 0.3em;
+		margin-bottom: 0;
+		margin-top: 0;
+	}
+
+	.Header-logo {
 		position: absolute;
 		top: 0.2em;
 		right: 0.2em;
 		opacity: 0.1;
 		transition: opacity 100ms;
 	}
-	.R4:hover {opacity: 1;}
-	p,
-	marquee {
+	.Header-logo:hover {
+		opacity: 1;
+	}
+	
+	.Header-track {
 		margin: 0;
 		font-size: 0.8125em;
 	}
@@ -73,12 +81,12 @@
 		display: block;
 		min-height: 1em; /* avoid jumps */
 	}
-	.Header-image {
+	.Header-media {
 		position: relative;
 		width: 2.75em;
 		height: 2.75em;
 	}
-	.Header-image img {
+	.Header-media img {
 		display: inline-block;
 		vertical-align: top;
 		width: 100%;

--- a/src/ProviderPlayer.vue
+++ b/src/ProviderPlayer.vue
@@ -58,9 +58,6 @@
 		background-color: black;
 		overflow: hidden;
 		position: relative;
-		flex-basis: 100%;
-		/* https://stackoverflow.com/questions/15381172/how-to-make-flexbox-children-100-height-of-their-parent */
-		display: flex;
 		/* Youtube requirements */
 		min-height: 200px;
 		min-width: 200px;

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -167,31 +167,24 @@
 	radio4000-player {
 		box-sizing: border-box;
 	}
-	radio4000-player *, radio4000-player *:before, radio4000-player*:after {
+	radio4000-player *,
+	radio4000-player *:before,
+	radio4000-player *:after {
 		box-sizing: inherit;
 	}
 	radio4000-player {
-		display: flex;
-		flex-direction: column;
+		display: block;
 		border: 1px solid hsl(0, 0%, 60%);
 		font-family: 'maisonneue', 'system-ui', sans-serif;
 		background-color: hsl(260, 10%, 92% );
 		color: hsl(0, 0%, 10%);
-
-		/* Responsive scaling. A min. width of 352px is required to show YouTube volume. */
 		font-size: 1em;
 		width: 100%;
-		/* tests */
-		/*min-height: calc(2.75em + 200px + 2.6em);*/
-		/*height: 80vh;*/
 	}
 </style>
 
 <style scoped>
 .R4PlayerLayout {
-	display: flex;
-	flex-direction: column;
-	flex: 1; /* full height */
 }
 .Body {
 	flex-basis: 20rem;

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -188,25 +188,29 @@
 </style>
 
 <style scoped>
-	.R4PlayerLayout {
-		display: flex;
-		flex-direction: column;
-		flex: 1; /* full height */
-	}
-	.Body {
-		display: flex;
-		flex-direction: column;
-		flex-basis: 20rem;
-		flex-grow: 1;
-		position: relative;
-		overflow: hidden;
-	}
-	@media screen and (min-width: 40rem) {
-		.Body {
-			flex-direction: row;
-			max-height: 80vh;
-		}
-	}
+.R4PlayerLayout {
+	display: flex;
+	flex-direction: column;
+	flex: 1; /* full height */
+}
+.Body {
+	flex-basis: 20rem;
+	flex-grow: 1;
+	position: relative;
+	overflow: hidden;
+	display: flex;
+	flex-wrap: wrap;
+}
+.Body>.ProviderPlayer {
+	flex-grow: 999999;
+	flex-shrink: 1;
+	flex-basis: 300px;
+}
+.Body>.TrackList {
+	flex-grow: 1;
+	flex-shrink: 1;
+	flex-basis: 20%;
+}
 </style>
 
 <style id="Radio4000-mini">

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -210,8 +210,9 @@
 	}
 	
 	.TrackList {
-		flex-basis: 300px;
+		flex-basis: 200px;
 		flex-grow: 1;
+		max-width: 400px;
 	}
 
 	.TrackList-list {

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -8,7 +8,7 @@
 				:r4Url="r4Url"
 				:track="currentTrack"></channel-header>
 
-		<main class="Body">	
+
 			<provider-player
 					:autoplay="autoplay"
 					:isMuted="isMuted"
@@ -17,15 +17,14 @@
 					:volume="volume"
 					@play="play"
 					@pause="pause"
-					@trackEnded="trackEnded"
-			></provider-player>
+					@trackEnded="trackEnded"></provider-player>
 
 			<track-list
 					:currentTrackIndex="currentTrackIndex"
 					:track="currentTrack"
 					:tracks="tracksPool"
 					@select="playTrack"></track-list>
-		</main>
+
 
 		<player-controls
 				:isDisabled="!this.tracksPool.length"
@@ -183,27 +182,44 @@
 	}
 </style>
 
-<style scoped>
-.R4PlayerLayout {
-}
-.Body {
-	flex-basis: 20rem;
-	flex-grow: 1;
-	position: relative;
-	overflow: hidden;
-	display: flex;
-	flex-wrap: wrap;
-}
-.Body>.ProviderPlayer {
-	flex-grow: 999999;
-	flex-shrink: 1;
-	flex-basis: 300px;
-}
-.Body>.TrackList {
-	flex-grow: 1;
-	flex-shrink: 1;
-	flex-basis: 20%;
-}
+<style>
+	/* 
+		 Follwing styles are used to make
+		 the player and all its child DOM elements
+		 responsive to its own size,
+		 without the need of a media queries
+		 (because they are triggered by viewport size)
+	 */
+
+	.R4PlayerLayout {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+	}
+
+	.Header,
+	.PlayerControl {
+		flex-grow: 1;
+		flex-basis: 100%;
+	}
+
+	.ProviderPlayer {
+		flex-basis: 200px;
+		flex-shrink: 0;
+		flex-grow: 1;
+	}
+	
+	.TrackList {
+		flex-basis: 300px;
+		flex-grow: 1;
+	}
+
+	.TrackList-list {
+		max-height: 30vh;
+    overflow-x: hidden;
+    overflow-y: scroll;
+	}
+
 </style>
 
 <style id="Radio4000-mini">

--- a/src/TrackList.vue
+++ b/src/TrackList.vue
@@ -51,20 +51,10 @@ export default {
 
 <style scoped>
 	.TrackList {
-		display: flex;
 		position: relative;
-		min-width: 200px;
-		overflow: hidden;
-	}
-	@media screen and (min-width: 40rem) {
-		.TrackList {
-			max-width: 40rem;
-		}
 	}
 	.TrackList-list {
 		margin: 0;
-		overflow-y: scroll;
-		overflow-x: hidden; /* firefox */
 		padding: 0;
 		list-style: none;
 		counter-reset: tracks;


### PR DESCRIPTION
This PR allows the Player to be responsive without the use of media-queries or javascript.

## What we wanted:
The player should switch from one column to two columns layout depending on whether there is space enough. That calculation should be made depending on **its own size (width)**, because this is what matters.

Note: it should work in Firefox and Chrome. IE not tested. We always only target major evergreen browsers.

## How it is achieved?
Flexbox, look at the code in `Radio4000Player.vue`'s styles.

## Why we don't use those techniques:
TLDR; those techniques are based on the viewport size
- media-queries: are triggered by the size of the viewport, so useless for us
- javascript: see #50, it does not work easily since the resize event listener can only listen the window. It is therefor as useless as media queries. 