### PR TITLE
fix/track-active

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -4,6 +4,7 @@ const host = 'https://radio4000.firebaseio.com'
 
 // Utilities for working with Firebase REST API.
 const parse = res => res.json()
+const serializeId = (data, id) => Object.assign(data, {id})
 const getFirst = arr => arr[0]
 const toArray = firebaseObj => {
 	return Object.keys(firebaseObj).map(id => {
@@ -32,7 +33,7 @@ export function findChannelTracks(id) {
 }
 export function findTrack(id) {
 	const url = `${host}/tracks/${id}.json`
-	return fetch(url).then(parse)
+	return fetch(url).then(parse).then(data => serializeId(data, id))
 }
 export function findChannelImage(channel) {
 	if (!channel || !channel.images) return


### PR DESCRIPTION
when player started by track, that track was never set as active since it missed the id in the object.

so vue could not find that exact object in the trackList array by comparing the two exact objects. (tracks in the list where serialized with the id)

serializing in the missing id fixed that