### PR TITLE
Feature: track ended, add previous track is event

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ You can listen for events directly on each `<radio4000-player>` element.
 
 ### Supported events
 
-- `trackChanged` - This event fires whenever the current track is changed.
-- `trackEnded` - This event fires when the current track finishes playing.
+- `trackChanged` - This event fires whenever the current track is
+  changed. It is an object containing two `track` objects,
+  `previousTrack` and `track`
+- `trackEnded` - This event fires when the current track finishes
+  playing. It is an object containing a `track` object.
 
 Here's an example of how to listen for the `trackChanged` event. It is the same approach for all events. In the case of both `trackChanged` and `trackEnded`, the `event.detail[0]` argument will be a Radio4000 `track` object.
 

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -115,8 +115,12 @@
 		methods: {
 			playTrack(track) {
 				console.log('playTrack')
+				const previousTrack = this.currentTrack;
 				this.currentTrack = track
-				this.$emit('trackChanged', track)
+				this.$emit('trackChanged', {
+					track,
+					previousTrack
+				})
 			},
 			newTracksPool() {
 				var newTracksPool = this.tracks.slice().reverse()


### PR DESCRIPTION
This PR mutates the `trackEnded` event.

The event object returned by this event contains now:
- `previousTrack` object
- `track` object